### PR TITLE
Implement review feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ rust:
   - stable
   - 1.38.0  # lowest rust release against which we guarantee compatibility.
 cache: cargo
+before_install:
+  - rustup component add clippy
+  - rustup component add rustfmt
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo clippy --verbose
+  - cargo fmt && [ `git status -s | wc -l` -eq 0 ] # check that all files are formatted with `cargo fmt`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 r2d2 = "0.8"
-oracle = "0.3"
+oracle = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ impl OracleConnectionManager {
     /// # use r2d2_oracle::OracleConnectionManager;
     /// // connect system/manager as sysdba
     /// let mut connector = oracle::Connector::new("system", "manager", "");
-    /// let connector = connector.privilege(oracle::Privilege::Sysdba);
-    /// let manager = OracleConnectionManager::from_connector(connector.clone());
+    /// connector.privilege(oracle::Privilege::Sysdba);
+    /// let manager = OracleConnectionManager::from_connector(connector);
     /// ```
     pub fn from_connector(connector: oracle::Connector) -> OracleConnectionManager {
         OracleConnectionManager { connector }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl r2d2::ManageConnection for OracleConnectionManager {
     }
 
     fn is_valid(&self, conn: &mut oracle::Connection) -> Result<(), oracle::Error> {
-        conn.query("SELECT 1 FROM dual", &[]).map(|_| ())
+        conn.ping()
     }
 
     fn has_broken(&self, conn: &mut oracle::Connection) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,9 @@ impl OracleConnectionManager {
     /// // connect system/manager as sysdba
     /// let mut connector = oracle::Connector::new("system", "manager", "");
     /// let connector = connector.privilege(oracle::Privilege::Sysdba);
-    /// let manager = OracleConnectionManager::new_with_connector(connector.clone());
+    /// let manager = OracleConnectionManager::from_connector(connector.clone());
     /// ```
-    pub fn new_with_connector(connector: oracle::Connector) -> OracleConnectionManager {
+    pub fn from_connector(connector: oracle::Connector) -> OracleConnectionManager {
         OracleConnectionManager { connector }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ impl r2d2::ManageConnection for OracleConnectionManager {
     }
 
     fn has_broken(&self, conn: &mut oracle::Connection) -> bool {
-        self.is_valid(conn).is_err()
+        match conn.status() {
+            Ok(oracle::ConnStatus::Normal) => false,
+            _ => true,
+        }
     }
 }


### PR DESCRIPTION
this implements the review feedback given by @kubo in kubo/rust-oracle#15

the only thing missing is the simplified `has_broken` implementation. i'll wait for @kubo to check if he can provide an API in his crate which internally uses oracle's `OCI_ATTR_SERVER_STATUS`.

@kubo: could you please review this PR? thanks!