### PR TITLE
Add "chrono" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ rust:
   - stable
   - 1.38.0  # lowest rust release against which we guarantee compatibility.
 cache: cargo
+env:
+  - FEATURES='--features chrono'
+  - FEATURES=''
 before_install:
   - rustup component add clippy
   - rustup component add rustfmt
 script:
-  - cargo build --verbose
+  - cargo build --verbose $FEATURES
   - cargo test --verbose
   - cargo clippy --verbose
   - cargo fmt && [ `git status -s | wc -l` -eq 0 ] # check that all files are formatted with `cargo fmt`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+chrono=["oracle/chrono"]
+
 [dependencies]
 r2d2 = "0.8"
 oracle = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ fn main() {
 }
 ```
 
+If you want to use chrono data types, enable the ```chrono``` feature:
+
+```
+[dependencies]
+r2d2-oracle = { version = "0.2.0", features = ["chrono"] }
+```
+
 ## Current Status of the Crate & Roadmap to v1.0.0
 This is the initial release of the crate and has not yet been proven in production. Nevertheless: the crate is very small so not many problems are expected.
 The precondition for releasing v1.0.0 is that both `r2d2` and `oracle` have released their v1.0.0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 #![deny(missing_docs)]
 
 //! Oracle support for the r2d2 connection pool.
+//!
+//! If you want to use chrono data types, enable the ```chrono``` feature:
+//!```toml
+//![dependencies]
+//!r2d2-oracle = { version = "0.2.0", features = ["chrono"] }
+//!```
 
 pub use oracle;
 pub use r2d2;


### PR DESCRIPTION
[rust-oracle](https://github.com/kubo/rust-oracle) crate provides a feature that adds various trait implementations for the [_chrono_ ](https://github.com/chronotope/chrono) crate that are particularly useful when working with dates.
This PR adds _chrono_ feature that enables the _chrono_ feature in rust-oracle