### PR TITLE
update minimum rust requirement to 1.42.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - 1.38.0  # lowest rust release against which we guarantee compatibility.
+  - 1.42.0  # lowest rust release against which we guarantee compatibility.
 cache: cargo
 env:
   - FEATURES='--features chrono'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+# 0.4.0
+* The minimum required `rustc` version is now 1.42.0
+
 # 0.3.0
 * Added support for the `chrono` feature of the `oracle` create by exposing it as the `chrono` feature here as well.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ This is the initial release of the crate and has not yet been proven in producti
 The precondition for releasing v1.0.0 is that both `r2d2` and `oracle` have released their v1.0.0.
 
 ## Build-time Requirements
-The crate is tested against stable rust and rust 1.38.0 (which was the stable version at the time the crate has been built).
+The crate is tested against stable rust and rust 1.42.0 (which was the stable version at the time the crate has been built).
 It is possible that it works with older versions as well but this is not tested.
 Please see the details of the r2d2 and oracle crates about their requirements.


### PR DESCRIPTION
with commit efe65cc i introduced the usage of the `matches!` macro. what
i didn't realise was that this had only been introduced with rust
1.42.0. sorry!

lession learnt: go through a pull request even for simple things - this
ensures that the full test matrix is executed! (because i of course
didn't try to compile with 1.38.0 locally...).

i presume that nobody will be using an old rust version anymore, so it's
probably save enough to just bump the minimum requirement. if somebody
is still using 1.38.0 .. < 1.42.0 you can stay on 0.3.x until you can
upgrade your compiler.