### PR TITLE
release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 0.5.0
+* Update to `oracle 0.5.1`
+
 # 0.4.0
 * The minimum required `rustc` version is now 1.42.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2d2-oracle"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Ralph Ursprung <ralph.ursprung@gmail.com>"]
 edition = "2018"
 description = "Oracle support for the r2d2 connection pool"


### PR DESCRIPTION
this changes the support for `oracle` from `0.4` to `0.5`.