### PR TITLE
README: fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # r2d2-oracle
-[![Build Status](https://travis-ci.com/rursprung/r2d2-oracle.svg?branch=master)](https://travis-ci.com/rursprung/r2d2-oracle)
+[![CI](https://github.com/rursprung/r2d2-oracle/actions/workflows/CI.yml/badge.svg)](https://github.com/rursprung/r2d2-oracle/actions/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/r2d2-oracle)](https://crates.io/crates/r2d2-oracle)
 ![Crates.io](https://img.shields.io/crates/l/r2d2-oracle)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)


### PR DESCRIPTION
the badge still pointed to Travis CI even though i moved to a GitHub workflow a while ago.