### PR TITLE
CI: audit: remove ignore of `time 0.1` vuln (no longer present)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,12 +36,8 @@ jobs:
         run: cargo check ${{ matrix.features }}
       - name: test
         run: cargo test ${{ matrix.features }}
-      - name: check formatting
-        run: cargo fmt --all -- --check
-      - name: audit
-        run: cargo audit
 
-  clippy:
+  static-code-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,3 +52,7 @@ jobs:
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true
+      - name: check formatting
+        run: cargo fmt --all -- --check
+      - name: audit
+        run: cargo audit


### PR DESCRIPTION
this is effectively a `git revert 15acb6d` (but not done as such to provide a more detailed commit message).
starting with chrono v0.4.30 the dependency to `time` has been removed, accordingly `cargo audit` no longer finds any issues here.